### PR TITLE
Refine orchestrator with modular process management

### DIFF
--- a/releases/current/orchestrator/healthcheck.py
+++ b/releases/current/orchestrator/healthcheck.py
@@ -1,0 +1,71 @@
+"""Health check helpers for launched games."""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+
+from manifest import GameEntry
+
+LOGGER = logging.getLogger("orchestrator.healthcheck")
+
+
+class HealthCheckError(Exception):
+    """Raised when the game fails to become healthy in time."""
+
+
+@dataclass
+class HealthCheckDefaults:
+    timeout_sec: float
+    interval_sec: float
+
+
+class HealthChecker:
+    def __init__(self, defaults: HealthCheckDefaults):
+        self._defaults = defaults
+        self._session = requests.Session()
+
+    def wait_until_healthy(self, game: GameEntry) -> None:
+        cfg = dict(game.healthcheck or {"type": "none"})
+        check_type = (cfg.get("type") or "none").lower()
+        if check_type == "none":
+            LOGGER.info("skipping healthcheck", extra={"game_id": game.id})
+            time.sleep(min(0.2, self._defaults.interval_sec))
+            return
+        if check_type == "http":
+            self._wait_http(game, cfg)
+            return
+        raise HealthCheckError(f"unknown healthcheck type: {check_type}")
+
+    def _wait_http(self, game: GameEntry, cfg: dict) -> None:
+        port = cfg.get("port")
+        if port is None:
+            raise HealthCheckError("http healthcheck requires 'port'")
+        path = cfg.get("path", "/health")
+        timeout = float(cfg.get("timeout_sec", self._defaults.timeout_sec))
+        interval = float(cfg.get("interval_sec", self._defaults.interval_sec))
+        url = f"http://127.0.0.1:{port}{path}"
+        deadline = time.time() + timeout
+        last_error: Optional[str] = None
+
+        LOGGER.info("waiting for http healthcheck", extra={"game_id": game.id, "url": url})
+        while time.time() < deadline:
+            try:
+                resp = self._session.get(url, timeout=interval)
+                if 200 <= resp.status_code < 300:
+                    LOGGER.info("healthcheck ok", extra={"game_id": game.id})
+                    return
+                last_error = f"status={resp.status_code}"
+            except requests.RequestException as exc:
+                last_error = str(exc)
+            time.sleep(interval)
+
+        raise HealthCheckError(
+            f"healthcheck timeout for {game.id}: {last_error or 'no successful response'}"
+        )
+
+
+__all__ = ["HealthChecker", "HealthCheckDefaults", "HealthCheckError"]

--- a/releases/current/orchestrator/intent_router.py
+++ b/releases/current/orchestrator/intent_router.py
@@ -1,0 +1,47 @@
+"""Intent routing utilities for MQTT payloads."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+LOGGER = logging.getLogger("orchestrator.intent_router")
+
+
+@dataclass
+class Intent:
+    type: str
+    game_name: Optional[str] = None
+    source: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+class IntentRouter:
+    def __init__(
+        self,
+        on_launch: Callable[[Intent], None],
+        on_exit: Callable[[Intent], None],
+    ) -> None:
+        self._on_launch = on_launch
+        self._on_exit = on_exit
+
+    def dispatch(self, payload: Dict[str, Any]) -> None:
+        if not isinstance(payload, dict):
+            LOGGER.error("intent payload must be a dict")
+            return
+        intent_type = (payload.get("type") or "").upper()
+        intent = Intent(
+            type=intent_type,
+            game_name=payload.get("game_name") or payload.get("game"),
+            source=payload.get("source"),
+            raw=payload,
+        )
+        if intent_type == "LAUNCH_GAME":
+            self._on_launch(intent)
+        elif intent_type in {"BACK_HOME", "QUIT"}:
+            self._on_exit(intent)
+        else:
+            LOGGER.info("ignoring unsupported intent", extra={"type": intent_type})
+
+
+__all__ = ["Intent", "IntentRouter"]

--- a/releases/current/orchestrator/manifest.py
+++ b/releases/current/orchestrator/manifest.py
@@ -1,0 +1,97 @@
+"""Manifest loading utilities for the game orchestrator."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from jsonschema import validate
+
+
+class ManifestError(Exception):
+    """Raised when the manifest file cannot be parsed or validated."""
+
+
+@dataclass
+class GameEntry:
+    """Single entry in the manifest."""
+
+    id: str
+    name: str
+    exec: str
+    synonyms: List[str]
+    workdir: Optional[str] = None
+    args: List[str] = field(default_factory=list)
+    env: Dict[str, str] = field(default_factory=dict)
+    healthcheck: Dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Normalize synonyms to lowercase for lookup simplicity.
+        self.synonyms = [s.lower() for s in self.synonyms]
+        # Ensure optional collections are always concrete types.
+        self.args = list(self.args or [])
+        self.env = dict(self.env or {})
+        self.healthcheck = dict(self.healthcheck or {})
+
+
+class Manifest:
+    """Loads and resolves entries from the manifest file."""
+
+    def __init__(self, manifest_path: str, schema_path: str):
+        self._manifest_path = manifest_path
+        self._schema_path = schema_path
+        self._games: Dict[str, GameEntry] = {}
+        self._syn_to_id: Dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            with open(self._manifest_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            with open(self._schema_path, "r", encoding="utf-8") as f:
+                schema = json.load(f)
+        except OSError as exc:
+            raise ManifestError(f"failed to load manifest: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise ManifestError(f"invalid manifest json: {exc}") from exc
+
+        try:
+            validate(instance=data, schema=schema)
+        except Exception as exc:  # jsonschema.ValidationError and friends
+            raise ManifestError(f"manifest validation failed: {exc}") from exc
+
+        games = data.get("games", [])
+        self._games.clear()
+        self._syn_to_id.clear()
+        for raw in games:
+            entry = GameEntry(
+                id=raw["id"],
+                name=raw["name"],
+                exec=raw["exec"],
+                synonyms=raw.get("synonyms", []),
+                workdir=raw.get("workdir"),
+                args=raw.get("args") or [],
+                env=raw.get("env") or {},
+                healthcheck=raw.get("healthcheck") or {"type": "none"},
+            )
+            self._games[entry.id] = entry
+            # Allow lookup by synonyms, name, and id (case-insensitive).
+            for key in entry.synonyms + [entry.name.lower(), entry.id.lower()]:
+                self._syn_to_id[key] = entry.id
+
+    def resolve(self, spoken: str) -> Optional[GameEntry]:
+        key = (spoken or "").lower().strip()
+        if not key:
+            return None
+        game_id = self._syn_to_id.get(key)
+        return self._games.get(game_id) if game_id else None
+
+    def get(self, game_id: str) -> Optional[GameEntry]:
+        return self._games.get(game_id)
+
+    @property
+    def games(self) -> List[GameEntry]:
+        return list(self._games.values())
+
+
+__all__ = ["Manifest", "GameEntry", "ManifestError"]

--- a/releases/current/orchestrator/process_manager.py
+++ b/releases/current/orchestrator/process_manager.py
@@ -1,0 +1,131 @@
+"""Process lifecycle management for launched games."""
+from __future__ import annotations
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+import psutil
+
+from manifest import GameEntry
+
+LOGGER = logging.getLogger("orchestrator.process_manager")
+
+
+@dataclass
+class ProcessExit:
+    """Information about a process exit event."""
+
+    game_id: Optional[str]
+    returncode: Optional[int]
+    expected: bool
+
+
+class ProcessManager:
+    """Start and stop games as child processes."""
+
+    def __init__(self) -> None:
+        self._proc: Optional[psutil.Process] = None
+        self._game: Optional[GameEntry] = None
+        self._stopping: bool = False
+
+    def is_running(self) -> bool:
+        return self._proc is not None and self._proc.is_running()
+
+    @property
+    def current_game_id(self) -> Optional[str]:
+        return self._game.id if self._game else None
+
+    def start(self, game: GameEntry) -> None:
+        if self.is_running():
+            raise RuntimeError("a game is already running")
+
+        env = os.environ.copy()
+        env.update(game.env or {})
+        cmd = [game.exec] + list(game.args or [])
+        LOGGER.info("launching game", extra={"cmd": cmd, "game_id": game.id})
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                cwd=game.workdir or None,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception as exc:
+            LOGGER.exception("failed to start game %s", game.id)
+            raise
+
+        self._proc = psutil.Process(proc.pid)
+        self._game = game
+        self._stopping = False
+
+    def stop(self, timeout_sec: float = 3.0) -> Optional[ProcessExit]:
+        if self._proc is None:
+            return None
+
+        proc = self._proc
+        game = self._game
+        self._stopping = True
+        LOGGER.info("stopping current game", extra={"game_id": game.id if game else None})
+        try:
+            if proc.is_running():
+                for child in proc.children(recursive=True):
+                    try:
+                        child.terminate()
+                    except Exception:
+                        LOGGER.debug("failed terminating child", exc_info=True)
+                try:
+                    proc.terminate()
+                except Exception:
+                    LOGGER.debug("terminate failed", exc_info=True)
+                gone, alive = psutil.wait_procs([proc], timeout=timeout_sec)
+                if alive:
+                    LOGGER.warning("force killing remaining process")
+                    for p in alive:
+                        try:
+                            p.kill()
+                        except Exception:
+                            LOGGER.debug("kill failed", exc_info=True)
+                        try:
+                            p.wait(timeout=timeout_sec)
+                        except Exception:
+                            LOGGER.debug("wait on kill failed", exc_info=True)
+        finally:
+            returncode: Optional[int] = None
+            try:
+                returncode = proc.wait(timeout=0)
+            except (psutil.TimeoutExpired, psutil.NoSuchProcess):
+                returncode = None
+            except psutil.Error:
+                LOGGER.debug("wait returned psutil error", exc_info=True)
+            self._proc = None
+            self._game = None
+            self._stopping = False
+        return ProcessExit(game_id=game.id if game else None, returncode=returncode, expected=True)
+
+    def poll_exit(self) -> Optional[ProcessExit]:
+        if self._proc is None:
+            return None
+
+        proc = self._proc
+        game = self._game
+        try:
+            returncode = proc.wait(timeout=0)
+        except psutil.TimeoutExpired:
+            return None
+        except psutil.NoSuchProcess:
+            returncode = proc.returncode
+        except psutil.Error:
+            LOGGER.debug("poll wait error", exc_info=True)
+            returncode = None
+
+        self._proc = None
+        self._game = None
+        expected = self._stopping
+        self._stopping = False
+        return ProcessExit(game_id=game.id if game else None, returncode=returncode, expected=expected)
+
+
+__all__ = ["ProcessManager", "ProcessExit"]

--- a/releases/current/orchestrator/ui.py
+++ b/releases/current/orchestrator/ui.py
@@ -1,0 +1,341 @@
+"""Simple Tkinter UI for interacting with the game orchestrator over MQTT."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import paho.mqtt.client as mqtt
+import tkinter as tk
+from tkinter import messagebox
+import yaml
+
+from manifest import GameEntry, Manifest, ManifestError
+
+LOGGER = logging.getLogger("orchestrator.ui")
+
+
+def load_yaml(path: str) -> Dict[str, Any]:
+    """Load a YAML file and return the parsed dictionary."""
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+Event = Tuple[str, Any]
+
+
+class OrchestratorUI:
+    """Tkinter-based control surface for the orchestrator."""
+
+    def __init__(
+        self,
+        root: tk.Tk,
+        *,
+        games: List[GameEntry],
+        mqtt_host: str,
+        mqtt_port: int,
+        intent_topic: str,
+        state_topic: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+    ) -> None:
+        self.root = root
+        self.root.title("Robot Game Launcher")
+        self.root.minsize(520, 420)
+        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+
+        self._games = games
+        self._mqtt_host = mqtt_host
+        self._mqtt_port = mqtt_port
+        self._intent_topic = intent_topic
+        self._state_topic = state_topic
+        self._username = username
+        self._password = password
+
+        self._events: "queue.Queue[Event]" = queue.Queue()
+        self._connected = False
+        self._alive = True
+        self._log_limit = 100
+
+        self.connection_var = tk.StringVar(value="Connecting…")
+        self.state_var = tk.StringVar(value="Mode: unknown • Game: –")
+        self.detail_var = tk.StringVar(value="")
+
+        self._build_layout()
+
+        # MQTT client setup
+        self._client = mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION2, client_id="orchestrator-ui"
+        )
+        if self._username:
+            self._client.username_pw_set(self._username, self._password or None)
+        self._client.enable_logger(logging.getLogger("orchestrator.ui.mqtt"))
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
+        self._client.on_message = self._on_message
+
+        self._append_log("Connecting to MQTT…")
+        self._client.loop_start()
+        try:
+            self._client.connect_async(self._mqtt_host, self._mqtt_port, keepalive=10)
+        except ValueError:
+            # Fallback for older versions where connect_async may be missing.
+            self._client.connect(self._mqtt_host, self._mqtt_port, keepalive=10)
+
+        self._schedule_event_pump()
+
+    def _build_layout(self) -> None:
+        frame = tk.Frame(self.root, padx=12, pady=12)
+        frame.pack(fill="both", expand=True)
+
+        title = tk.Label(frame, text="Robot Game Launcher", font=("Segoe UI", 16, "bold"))
+        title.pack(anchor="w")
+
+        status_frame = tk.Frame(frame)
+        status_frame.pack(fill="x", pady=(10, 6))
+        tk.Label(status_frame, text="Connection:", width=12, anchor="w").pack(
+            side="left"
+        )
+        tk.Label(status_frame, textvariable=self.connection_var, anchor="w").pack(
+            side="left", fill="x", expand=True
+        )
+
+        state_box = tk.LabelFrame(frame, text="Current state")
+        state_box.pack(fill="x", pady=(4, 10))
+        tk.Label(state_box, textvariable=self.state_var, anchor="w").pack(
+            anchor="w", padx=8, pady=(6, 2)
+        )
+        tk.Label(state_box, textvariable=self.detail_var, anchor="w", fg="#555555").pack(
+            anchor="w", padx=8, pady=(0, 6)
+        )
+
+        game_frame = tk.LabelFrame(frame, text="Available games")
+        game_frame.pack(fill="both", expand=True)
+        self.game_list = tk.Listbox(game_frame, height=6, exportselection=False)
+        self.game_list.pack(side="left", fill="both", expand=True, padx=(8, 0), pady=8)
+
+        scrollbar = tk.Scrollbar(game_frame, orient="vertical", command=self.game_list.yview)
+        scrollbar.pack(side="right", fill="y", padx=(0, 8), pady=8)
+        self.game_list.configure(yscrollcommand=scrollbar.set)
+
+        for game in self._games:
+            label = f"{game.name} ({game.id})"
+            self.game_list.insert(tk.END, label)
+
+        button_frame = tk.Frame(frame)
+        button_frame.pack(fill="x", pady=(6, 0))
+        launch_btn = tk.Button(button_frame, text="Launch Selected", command=self.launch_selected)
+        launch_btn.pack(side="left")
+        exit_btn = tk.Button(button_frame, text="Back to Hub", command=self.send_exit_intent)
+        exit_btn.pack(side="left", padx=(8, 0))
+
+        log_frame = tk.LabelFrame(frame, text="Recent events")
+        log_frame.pack(fill="both", expand=True, pady=(12, 0))
+        self.log_list = tk.Listbox(log_frame, height=8)
+        self.log_list.pack(fill="both", expand=True, padx=8, pady=8)
+
+    def _schedule_event_pump(self) -> None:
+        if not self._alive:
+            return
+        self.root.after(200, self._drain_events)
+
+    def _drain_events(self) -> None:
+        if not self._alive:
+            return
+        while True:
+            try:
+                event_type, payload = self._events.get_nowait()
+            except queue.Empty:
+                break
+            if event_type == "connection":
+                self._handle_connection_event(payload)
+            elif event_type == "state":
+                self._handle_state_event(payload)
+            elif event_type == "log":
+                self._append_log(str(payload))
+        self._schedule_event_pump()
+
+    def _handle_connection_event(self, payload: Dict[str, Any]) -> None:
+        status = payload.get("status")
+        if status == "connected":
+            self._connected = True
+            reason = payload.get("reason")
+            message = "Connected"
+            if reason is not None:
+                message = f"Connected (rc={reason})"
+            self.connection_var.set(message)
+            self._append_log("Connected to MQTT broker")
+            # Subscribe after we know we are connected
+            self._client.subscribe(self._state_topic)
+        elif status == "connect_error":
+            self._connected = False
+            self.connection_var.set("Connection failed")
+            detail = payload.get("detail", "unknown error")
+            self._append_log(f"MQTT connect error: {detail}")
+        elif status == "disconnected":
+            self._connected = False
+            rc = payload.get("reason")
+            message = "Disconnected"
+            if rc is not None:
+                message = f"Disconnected (rc={rc})"
+            self.connection_var.set(message)
+            self._append_log("Disconnected from MQTT broker")
+
+    def _handle_state_event(self, payload: Dict[str, Any]) -> None:
+        mode = str(payload.get("mode", "UNKNOWN")).upper()
+        game_id = payload.get("game_id") or "–"
+        detail = payload.get("detail") or ""
+        self.state_var.set(f"Mode: {mode} • Game: {game_id}")
+        self.detail_var.set(detail)
+
+        timestamp = payload.get("ts")
+        if isinstance(timestamp, (int, float)):
+            ts_text = datetime.fromtimestamp(timestamp).strftime("%H:%M:%S")
+        else:
+            ts_text = datetime.now().strftime("%H:%M:%S")
+
+        summary = f"{ts_text} • {mode} ({game_id})"
+        if detail:
+            summary = f"{summary} — {detail}"
+        self._append_log(summary)
+
+        if mode == "RUNNING":
+            for idx, game in enumerate(self._games):
+                if game.id == game_id:
+                    self.game_list.selection_clear(0, tk.END)
+                    self.game_list.selection_set(idx)
+                    self.game_list.see(idx)
+                    break
+        elif mode in {"IDLE", "ERROR"}:
+            self.game_list.selection_clear(0, tk.END)
+
+    def _append_log(self, message: str) -> None:
+        self.log_list.insert(tk.END, message)
+        if self.log_list.size() > self._log_limit:
+            self.log_list.delete(0)
+        self.log_list.see(tk.END)
+
+    def _publish_intent(self, payload: Dict[str, Any]) -> None:
+        if not self._connected:
+            messagebox.showwarning("Not connected", "MQTT broker is not connected yet.")
+            return
+        try:
+            self._client.publish(self._intent_topic, json.dumps(payload))
+            self._append_log(f"Published {payload.get('type')} intent")
+        except Exception as exc:  # pragma: no cover - defensive UI reporting
+            LOGGER.exception("failed to publish intent")
+            messagebox.showerror("Publish failed", f"Unable to publish intent: {exc}")
+
+    def launch_selected(self) -> None:
+        selection = self.game_list.curselection()
+        if not selection:
+            messagebox.showinfo("Select a game", "Please choose a game to launch.")
+            return
+        game = self._games[selection[0]]
+        self._publish_intent(
+            {
+                "type": "LAUNCH_GAME",
+                "game_name": game.name,
+                "source": "ui",
+            }
+        )
+
+    def send_exit_intent(self) -> None:
+        self._publish_intent({"type": "BACK_HOME", "source": "ui"})
+
+    def _on_connect(self, client, userdata, flags, reason_code, properties=None):  # type: ignore[override]
+        if reason_code == 0:
+            self._events.put(("connection", {"status": "connected", "reason": reason_code}))
+        else:
+            self._events.put(
+                (
+                    "connection",
+                    {
+                        "status": "connect_error",
+                        "detail": f"rc={reason_code}",
+                    },
+                )
+            )
+
+    def _on_disconnect(self, client, userdata, reason_code, properties=None):  # type: ignore[override]
+        self._events.put(("connection", {"status": "disconnected", "reason": reason_code}))
+
+    def _on_message(self, client, userdata, msg):  # type: ignore[override]
+        try:
+            payload = json.loads(msg.payload.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            self._events.put(("log", f"Invalid state payload: {exc}"))
+            return
+        if not isinstance(payload, dict):
+            self._events.put(("log", "Ignored non-dict state payload"))
+            return
+        self._events.put(("state", payload))
+
+    def on_close(self) -> None:
+        self.shutdown()
+        self.root.destroy()
+
+    def shutdown(self) -> None:
+        if not self._alive:
+            return
+        self._alive = False
+        try:
+            self._client.disconnect()
+        except Exception:
+            pass
+        try:
+            self._client.loop_stop(force=True)
+        except Exception:
+            pass
+        self.connection_var.set("Disconnected")
+        self._append_log("UI closed")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    config_path = os.path.join(repo_root, "config", "ports.yaml")
+    manifest_path = os.path.join(repo_root, "config", "manifest.json")
+    schema_path = os.path.join(repo_root, "config", "manifest.schema.json")
+
+    root = tk.Tk()
+
+    try:
+        config = load_yaml(config_path)
+    except OSError as exc:
+        messagebox.showerror("Configuration error", f"Failed to load {config_path}: {exc}")
+        root.destroy()
+        return
+
+    mqtt_cfg = config.get("mqtt", {})
+    topics_cfg = config.get("topics", {})
+
+    try:
+        manifest = Manifest(manifest_path, schema_path)
+    except ManifestError as exc:
+        messagebox.showerror("Manifest error", str(exc))
+        root.destroy()
+        return
+
+    ui = OrchestratorUI(
+        root,
+        games=manifest.games,
+        mqtt_host=mqtt_cfg.get("host", "127.0.0.1"),
+        mqtt_port=int(mqtt_cfg.get("port", 1883)),
+        intent_topic=topics_cfg.get("intent", "robot/intent"),
+        state_topic=topics_cfg.get("state", "robot/state"),
+        username=mqtt_cfg.get("username") or None,
+        password=mqtt_cfg.get("password") or None,
+    )
+
+    try:
+        root.mainloop()
+    finally:
+        ui.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- modularized the orchestrator into dedicated manifest, process management, health-check, and intent routing modules
- extended orchestrator to run health checks, monitor unexpected exits, and provide richer MQTT state updates
- added a Tkinter-based desktop UI to publish intents and display orchestrator state via MQTT

## Testing
- python -m compileall releases/current/orchestrator

------
https://chatgpt.com/codex/tasks/task_e_68d180d332b88331b89d414e2084ee2b