### PR TITLE
Add dependency guards for orchestrator entry points

### DIFF
--- a/releases/current/orchestrator/dependency_guard.py
+++ b/releases/current/orchestrator/dependency_guard.py
@@ -1,0 +1,43 @@
+"""Utility helpers for checking orchestrator optional dependencies."""
+from __future__ import annotations
+
+import importlib
+from typing import Callable, Iterable
+
+_REQUIREMENTS_PATH = "releases/current/orchestrator/requirements.txt"
+
+
+def dependency_message(module_name: str) -> str:
+    """Return the user-facing message for a missing dependency."""
+    return (
+        f"Missing dependency '{module_name}'. Please run "
+        f"'pip install -r {_REQUIREMENTS_PATH}' before re-running."
+    )
+
+
+def ensure_dependencies(
+    modules: Iterable[str],
+    on_error: Callable[[str, str], None],
+) -> None:
+    """Import each module name, calling *on_error* if an ImportError occurs.
+
+    Parameters
+    ----------
+    modules:
+        An iterable of dotted module names to import.
+    on_error:
+        Callback receiving ``(module_name, friendly_message)`` when an import
+        fails. The helper will exit the process with ``SystemExit(1)`` after the
+        callback returns.
+    """
+
+    for module_name in modules:
+        try:
+            importlib.import_module(module_name)
+        except ImportError as exc:
+            message = dependency_message(module_name)
+            on_error(module_name, message)
+            raise SystemExit(1) from exc
+
+
+__all__ = ["dependency_message", "ensure_dependencies"]

--- a/releases/current/orchestrator/orchestrator.py
+++ b/releases/current/orchestrator/orchestrator.py
@@ -7,15 +7,24 @@ import os
 import time
 from typing import Any, Dict, Optional
 
-import paho.mqtt.client as mqtt
-import yaml
-
-from healthcheck import HealthCheckDefaults, HealthCheckError, HealthChecker
-from intent_router import Intent, IntentRouter
-from manifest import Manifest, ManifestError
-from process_manager import ProcessExit, ProcessManager
+from dependency_guard import ensure_dependencies
 
 LOGGER = logging.getLogger("orchestrator")
+
+
+def _log_dependency_error(module: str, message: str) -> None:
+    LOGGER.error(message)
+
+
+ensure_dependencies(("paho.mqtt.client", "yaml"), _log_dependency_error)
+
+import paho.mqtt.client as mqtt  # noqa: E402
+import yaml  # noqa: E402
+
+from healthcheck import HealthCheckDefaults, HealthCheckError, HealthChecker  # noqa: E402
+from intent_router import Intent, IntentRouter  # noqa: E402
+from manifest import Manifest, ManifestError  # noqa: E402
+from process_manager import ProcessExit, ProcessManager  # noqa: E402
 
 
 def setup_logging() -> None:

--- a/releases/current/orchestrator/ui.py
+++ b/releases/current/orchestrator/ui.py
@@ -8,14 +8,25 @@ import queue
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-import paho.mqtt.client as mqtt
 import tkinter as tk
 from tkinter import messagebox
-import yaml
 
-from manifest import GameEntry, Manifest, ManifestError
+from dependency_guard import ensure_dependencies
 
 LOGGER = logging.getLogger("orchestrator.ui")
+
+
+def _show_dependency_error(module: str, message: str) -> None:
+    LOGGER.error(message)
+    messagebox.showerror("Missing dependency", message)
+
+
+ensure_dependencies(("paho.mqtt.client", "yaml"), _show_dependency_error)
+
+import paho.mqtt.client as mqtt  # noqa: E402
+import yaml  # noqa: E402
+
+from manifest import GameEntry, Manifest, ManifestError  # noqa: E402
 
 
 def load_yaml(path: str) -> Dict[str, Any]:

--- a/tests/test_dependency_guard.py
+++ b/tests/test_dependency_guard.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ORCHESTRATOR_ROOT = REPO_ROOT / "releases" / "current" / "orchestrator"
+
+
+def _prepare_missing_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure orchestrator modules are (re)loaded from the repo path."""
+    monkeypatch.syspath_prepend(str(ORCHESTRATOR_ROOT))
+    for name in ("orchestrator", "ui", "dependency_guard"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    for name in ("paho", "paho.mqtt", "paho.mqtt.client"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_orchestrator_entrypoint_missing_dependency(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    _prepare_missing_dependency(monkeypatch)
+    dependency_guard = importlib.import_module("dependency_guard")
+    original_import = dependency_guard.importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "paho.mqtt.client":
+            raise ImportError("missing module")
+        return original_import(name, package)
+
+    monkeypatch.setattr(dependency_guard.importlib, "import_module", fake_import)
+
+    with pytest.raises(SystemExit) as excinfo:
+        importlib.import_module("orchestrator")
+
+    assert excinfo.value.code == 1
+    message = caplog.text
+    assert "pip install -r releases/current/orchestrator/requirements.txt" in message
+    assert "paho.mqtt.client" in message
+    sys.modules.pop("orchestrator", None)
+
+
+def test_ui_entrypoint_missing_dependency(monkeypatch: pytest.MonkeyPatch):
+    _prepare_missing_dependency(monkeypatch)
+    dependency_guard = importlib.import_module("dependency_guard")
+    original_import = dependency_guard.importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "paho.mqtt.client":
+            raise ImportError("missing module")
+        return original_import(name, package)
+
+    monkeypatch.setattr(dependency_guard.importlib, "import_module", fake_import)
+
+    calls: list[tuple[str, str]] = []
+
+    def record_messagebox(title: str, message: str) -> None:
+        calls.append((title, message))
+
+    monkeypatch.setattr("tkinter.messagebox.showerror", record_messagebox)
+
+    with pytest.raises(SystemExit) as excinfo:
+        importlib.import_module("ui")
+
+    assert excinfo.value.code == 1
+    assert calls, "Expected the UI to show a dependency error dialog"
+    title, message = calls[0]
+    assert "Missing dependency" in title
+    assert "pip install -r releases/current/orchestrator/requirements.txt" in message
+    assert "paho.mqtt.client" in message
+    sys.modules.pop("ui", None)

--- a/tests/test_orchestrator_smoke.py
+++ b/tests/test_orchestrator_smoke.py
@@ -3,7 +3,12 @@ import os
 import threading
 import time
 
-import paho.mqtt.client as mqtt
+import pytest
+
+mqtt = pytest.importorskip(
+    "paho.mqtt.client",
+    reason="paho-mqtt is required for the orchestrator smoke test",
+)
 
 
 def load_ports_yaml():

--- a/tools/mqtt_smoke_test.py
+++ b/tools/mqtt_smoke_test.py
@@ -4,7 +4,10 @@ import queue
 import threading
 import time
 
-import paho.mqtt.client as mqtt
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:  # pragma: no cover - exercised in environments without paho
+    mqtt = None
 
 
 def load_ports_yaml():
@@ -15,6 +18,13 @@ def load_ports_yaml():
 
 
 def main():
+    if mqtt is None:
+        print(
+            "Missing dependency 'paho.mqtt.client'. Please run "
+            "'pip install -r releases/current/orchestrator/requirements.txt' first.",
+        )
+        return 1
+
     cfg = load_ports_yaml()
     host = cfg['mqtt']['host']
     port = int(cfg['mqtt']['port'])


### PR DESCRIPTION
## Summary
- introduce a reusable dependency guard for orchestrator components
- apply the guard to the service and UI entry points so missing packages surface clear guidance
- add regression tests and skip helpers for environments without the MQTT client dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d18c7852f88331820f3a43546cef3c