### PR TITLE
Add Unity Vosk voice launcher integration

### DIFF
--- a/releases/current/voice/unity_vosk_launcher/MqttIntentPublisher.cs
+++ b/releases/current/voice/unity_vosk_launcher/MqttIntentPublisher.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
+using MQTTnet.Protocol;
+using UnityEngine;
+
+namespace RobotVoice
+{
+    public class MqttIntentPublisher : MonoBehaviour
+    {
+        [Header("MQTT Broker")]
+        [SerializeField] private string host = "127.0.0.1";
+        [SerializeField] private int port = 1883;
+        [SerializeField] private string username = string.Empty;
+        [SerializeField] private string password = string.Empty;
+        [SerializeField] private string intentTopic = "robot/intent";
+        [SerializeField] private string clientId = "unity-voice";
+        [SerializeField] private bool autoConnectOnStart = true;
+        [SerializeField] private string sourceLabel = "unity_vosk";
+
+        private IMqttClient client;
+        private IMqttClientOptions options;
+        private readonly SemaphoreSlim connectLock = new SemaphoreSlim(1, 1);
+        private MqttFactory factory;
+
+        private void Awake()
+        {
+            InitialiseClient();
+        }
+
+        private async void Start()
+        {
+            if (autoConnectOnStart)
+            {
+                await EnsureConnectedAsync();
+            }
+        }
+
+        private void InitialiseClient()
+        {
+            factory = new MqttFactory();
+            client = factory.CreateMqttClient();
+            client.ConnectedAsync += e =>
+            {
+                Debug.Log($"[RobotVoice] Connected to MQTT {host}:{port}");
+                return Task.CompletedTask;
+            };
+            client.DisconnectedAsync += async e =>
+            {
+                Debug.LogWarning($"[RobotVoice] Disconnected from MQTT: {e.Reason}");
+                if (autoConnectOnStart)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2));
+                    await EnsureConnectedAsync();
+                }
+            };
+        }
+
+        public async Task EnsureConnectedAsync()
+        {
+            if (client == null)
+            {
+                InitialiseClient();
+            }
+
+            await connectLock.WaitAsync();
+            try
+            {
+                if (client.IsConnected)
+                {
+                    return;
+                }
+
+                var builder = new MqttClientOptionsBuilder()
+                    .WithTcpServer(host, port)
+                    .WithClientId(string.IsNullOrWhiteSpace(clientId) ? Guid.NewGuid().ToString("N") : clientId)
+                    .WithKeepAlivePeriod(TimeSpan.FromSeconds(15))
+                    .WithCleanSession();
+
+                if (!string.IsNullOrEmpty(username))
+                {
+                    builder = builder.WithCredentials(username, password ?? string.Empty);
+                }
+
+                options = builder.Build();
+                await client.ConnectAsync(options, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[RobotVoice] MQTT connect failed: {ex.Message}");
+            }
+            finally
+            {
+                connectLock.Release();
+            }
+        }
+
+        public async Task PublishLaunchIntentAsync(string gameName, string rawText)
+        {
+            if (string.IsNullOrWhiteSpace(gameName))
+            {
+                Debug.LogWarning("[RobotVoice] Ignoring empty game name");
+                return;
+            }
+
+            await PublishAsync(BuildLaunchPayload(gameName.Trim(), rawText));
+        }
+
+        public async Task PublishExitIntentAsync(string rawText)
+        {
+            await PublishAsync(BuildExitPayload(rawText));
+        }
+
+        private async Task PublishAsync(string payload)
+        {
+            await EnsureConnectedAsync();
+            if (client == null || !client.IsConnected)
+            {
+                Debug.LogWarning("[RobotVoice] MQTT client not connected; intent not sent");
+                return;
+            }
+
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic(intentTopic)
+                .WithPayload(payload)
+                .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
+                .Build();
+
+            try
+            {
+                await client.PublishAsync(message, CancellationToken.None);
+                Debug.Log($"[RobotVoice] Intent published: {payload}");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[RobotVoice] Failed to publish MQTT intent: {ex.Message}");
+            }
+        }
+
+        private string BuildLaunchPayload(string gameName, string rawText)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"type\":\"LAUNCH_GAME\"");
+            sb.Append(",\"game_name\":\"").Append(EscapeJson(gameName)).Append("\"");
+            sb.Append(",\"source\":\"").Append(EscapeJson(sourceLabel)).Append("\"");
+            if (!string.IsNullOrWhiteSpace(rawText))
+            {
+                sb.Append(",\"raw_text\":\"").Append(EscapeJson(rawText.Trim())).Append("\"");
+            }
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        private string BuildExitPayload(string rawText)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"type\":\"BACK_HOME\"");
+            sb.Append(",\"source\":\"").Append(EscapeJson(sourceLabel)).Append("\"");
+            if (!string.IsNullOrWhiteSpace(rawText))
+            {
+                sb.Append(",\"raw_text\":\"").Append(EscapeJson(rawText.Trim())).Append("\"");
+            }
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        private static string EscapeJson(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            foreach (var ch in value)
+            {
+                switch (ch)
+                {
+                    case '\\':
+                        sb.Append("\\\\");
+                        break;
+                    case '"':
+                        sb.Append("\\\"");
+                        break;
+                    case '\n':
+                        sb.Append("\\n");
+                        break;
+                    case '\r':
+                        sb.Append("\\r");
+                        break;
+                    case '\t':
+                        sb.Append("\\t");
+                        break;
+                    default:
+                        sb.Append(ch);
+                        break;
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private async void OnDestroy()
+        {
+            if (client != null && client.IsConnected)
+            {
+                try
+                {
+                    await client.DisconnectAsync();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning($"[RobotVoice] MQTT disconnect failed: {ex.Message}");
+                }
+            }
+
+            client?.Dispose();
+            connectLock?.Dispose();
+        }
+    }
+}

--- a/releases/current/voice/unity_vosk_launcher/README.md
+++ b/releases/current/voice/unity_vosk_launcher/README.md
@@ -1,0 +1,112 @@
+# Unity Vosk Voice Launcher
+
+This folder contains Unity-side glue code that connects the [Unity_Vosk](https://github.com/AmamiyaRenO/Unity_Vosk) speech recogniser to the Robot orchestrator.  When a player says
+"打开 记事本" ("open notepad"), the recogniser publishes a `LAUNCH_GAME` intent to MQTT (`robot/intent`) and the orchestrator starts the game that matches the manifest synonyms.
+
+The integration is intentionally lightweight: Unity handles microphone capture and speech-to-text through Unity_Vosk, while MQTT is used to notify the Python orchestrator that a game should
+start or stop.
+
+## Project structure
+
+```
+Assets/
+  RobotVoice/
+    MqttIntentPublisher.cs        # MQTT helper (MQTTnet) for publishing intents
+    VoiceGameLauncher.cs          # Parses recognised text and issues intents
+    VoiceIntentConfig.cs          # Serializable data model used by VoiceGameLauncher
+```
+
+A sample `voice_intents.example.json` file is provided to document the serialised format that can be created inside Unity via a `TextAsset`.
+
+## Prerequisites
+
+1. **Unity_Vosk** – follow the instructions from the upstream repository to import the package (either as a git submodule or by copying the `Assets/Vosk` folder).  Confirm that the demo
+   scene can recognise speech using the Vosk model you intend to ship with the product (Chinese, English, etc.).
+2. **Vosk acoustic model** – download an offline Vosk model that matches your target language and place it in your Unity project (for Chinese, `vosk-model-small-cn-0.22` works well for
+   prototypes).
+3. **MQTTnet for Unity** – install the [`MQTTnet`](https://github.com/dotnet/MQTTnet) client library.  The simplest option is to import the `MQTTnet.Unity` package from the releases page or
+   use a NuGet importer such as [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity) and install version `4.3.x` (which supports .NET Standard 2.0).
+4. **Robot orchestrator running** – start the Python orchestrator from this repository so it can accept intents:
+
+   ```powershell
+   # Windows PowerShell example
+   python .\releases\current\orchestrator\orchestrator.py
+   ```
+
+   Ensure Mosquitto (or another MQTT broker) is accessible on the host/port configured in `config/ports.yaml` (default `127.0.0.1:1883`).
+
+## Unity setup steps
+
+1. **Create a GameObject** (e.g. `VoiceLauncher`) and add the following components:
+   - `VoskSpeechRecognizer` (from Unity_Vosk) – configure the microphone, sample rate, and point it at your downloaded model directory.
+   - `MqttIntentPublisher` – fill in the broker information (`Host`, `Port`, credentials, and MQTT topic if different from `robot/intent`).
+   - `VoiceGameLauncher` – drag the `MqttIntentPublisher` component into its `Publisher` field.  Provide an intent configuration (either through the inspector lists or by assigning
+     the bundled `voice_intents.example.json` as a `TextAsset`).
+
+2. **Wire Unity_Vosk events to the launcher** – in the `VoskSpeechRecognizer` component, locate the `OnFinalResult` (or equivalent) `UnityEvent<string>` that fires when the recogniser
+   produces the final transcription.  Add the `VoiceGameLauncher.HandleVoskResult` method as a listener so that every recognised utterance is forwarded to the launcher.
+
+3. **(Optional) Wake word** – set the `Wake Word` field (for example `嘿机器人` or `hey robot`).  When `Require Wake Word` is ticked, the launcher will ignore any phrase that does not
+   begin with the wake word.  If the wake word is present it will be stripped before intent parsing so that the game name is preserved.
+
+4. **Launch/exit keywords** – adjust the `Launch Keywords` list so that it contains verbs your users are likely to speak (defaults include `打开`, `启动`, `open`, `play`).  Anything that
+   appears after one of these keywords is treated as the game name.  Likewise, populate `Exit Keywords` with phrases such as `退出`, `回到大厅`, `back to lobby`, or `quit game`.
+
+5. **Test end-to-end** – enter Play Mode and say `嘿机器人 打开 记事本`.  In the Unity console you should see a log entry from `VoiceGameLauncher` indicating that it published a
+   `LAUNCH_GAME` intent.  The orchestrator should then start the game defined in `config/manifest.json`.  Saying `嘿机器人 回到大厅` should publish a `BACK_HOME` intent, returning to the hub.
+
+## Runtime behaviour
+
+- `VoiceGameLauncher` receives recognised text (plain string or JSON from Vosk), extracts the sentence, enforces the wake word, and matches launch/exit keywords.
+- When a launch keyword is found, the remainder of the sentence is used as `game_name` and a payload similar to the following is published to `robot/intent`:
+
+  ```json
+  {
+    "type": "LAUNCH_GAME",
+    "game_name": "记事本",
+    "source": "unity_vosk",
+    "raw_text": "嘿机器人 打开 记事本"
+  }
+  ```
+
+- Exit keywords publish `{"type": "BACK_HOME", "source": "unity_vosk"}`.
+- A short cooldown (configurable) prevents duplicate intents from the same utterance.
+
+## voice_intents.example.json
+
+Use this file as a template when creating your own intent configuration.  Create a `TextAsset` in Unity from the JSON and assign it to `VoiceGameLauncher`.
+
+```json
+{
+  "WakeWord": "嘿机器人",
+  "LaunchKeywords": ["打开", "启动", "open"],
+  "ExitKeywords": ["退出", "回到大厅", "quit"],
+  "SynonymOverrides": [
+    {
+      "Spoken": "记事本",
+      "GameName": "记事本"
+    },
+    {
+      "Spoken": "notebook",
+      "GameName": "记事本"
+    }
+  ]
+}
+```
+
+- `WakeWord` – optional wake word.  Leave empty to accept any phrase.
+- `LaunchKeywords` – verbs that trigger a launch.  The text after the first keyword becomes the `game_name`.
+- `ExitKeywords` – phrases that trigger `BACK_HOME`.
+- `SynonymOverrides` – optional mappings that replace spoken phrases with manifest-friendly names before publishing.  This is useful when the recognised output contains filler words or
+  different spacing compared to the manifest synonyms.
+
+## Troubleshooting
+
+- **Nothing happens in Unity** – confirm that Unity_Vosk is calling `HandleVoskResult`.  Use `Debug.Log` in the recogniser callback to print the JSON string.
+- **MQTT connection errors** – check the host/port/credentials and verify that the MQTT broker allows TCP connections from the device running Unity.  The Unity console will display
+  errors from `MqttIntentPublisher` if authentication fails.
+- **Game not launching** – inspect the orchestrator logs.  If the recogniser produced an unexpected string, add it to `SynonymOverrides` or update `config/manifest.json` with additional
+  synonyms.
+- **Multiple launches** – increase `Intent Cooldown Seconds` in `VoiceGameLauncher` so that repeated partial results do not spam intents.
+
+With these scripts the Unity client can drive the existing orchestrator purely through speech recognition powered by Unity_Vosk.

--- a/releases/current/voice/unity_vosk_launcher/VoiceGameLauncher.cs
+++ b/releases/current/voice/unity_vosk_launcher/VoiceGameLauncher.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Globalization;
+using System.Text;
+using UnityEngine;
+
+namespace RobotVoice
+{
+    public class VoiceGameLauncher : MonoBehaviour
+    {
+        [Header("Dependencies")]
+        [SerializeField] private MqttIntentPublisher publisher;
+
+        [Header("Configuration")]
+        [SerializeField] private TextAsset intentConfigJson;
+        [SerializeField] private string wakeWord = "嘿机器人";
+        [SerializeField] private bool requireWakeWord = true;
+        [SerializeField] private bool requireLaunchKeyword = false;
+        [SerializeField] private string[] launchKeywords = { "打开", "启动", "open", "play" };
+        [SerializeField] private string[] exitKeywords = { "退出", "回到大厅", "quit", "back to lobby" };
+        [SerializeField] private SynonymOverride[] synonymOverrides = Array.Empty<SynonymOverride>();
+        [SerializeField] private float intentCooldownSeconds = 1.5f;
+        [SerializeField] private bool logDebugMessages = true;
+
+        private float lastIntentTime = -999f;
+        private VoiceIntentConfig runtimeConfig;
+
+        private void Awake()
+        {
+            runtimeConfig = BuildRuntimeConfig();
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            runtimeConfig = BuildRuntimeConfig();
+        }
+#endif
+
+        private VoiceIntentConfig BuildRuntimeConfig()
+        {
+            VoiceIntentConfig config = null;
+            if (intentConfigJson != null && !string.IsNullOrWhiteSpace(intentConfigJson.text))
+            {
+                config = VoiceIntentConfig.LoadFromJson(intentConfigJson.text);
+            }
+
+            if (config == null)
+            {
+                config = new VoiceIntentConfig();
+            }
+
+            if (config.LaunchKeywords == null || config.LaunchKeywords.Length == 0)
+            {
+                config.LaunchKeywords = launchKeywords != null && launchKeywords.Length > 0
+                    ? launchKeywords
+                    : new[] { "打开", "启动", "open", "play" };
+            }
+
+            if (config.ExitKeywords == null || config.ExitKeywords.Length == 0)
+            {
+                config.ExitKeywords = exitKeywords != null && exitKeywords.Length > 0
+                    ? exitKeywords
+                    : new[] { "退出", "回到大厅", "quit", "stop" };
+            }
+
+            if (config.SynonymOverrides == null || config.SynonymOverrides.Length == 0)
+            {
+                config.SynonymOverrides = synonymOverrides ?? Array.Empty<SynonymOverride>();
+            }
+
+            if (string.IsNullOrWhiteSpace(config.WakeWord))
+            {
+                config.WakeWord = wakeWord ?? string.Empty;
+            }
+
+            return config;
+        }
+
+        public void HandleVoskResult(string message)
+        {
+            if (publisher == null)
+            {
+                Debug.LogError("[RobotVoice] VoiceGameLauncher missing MqttIntentPublisher reference");
+                return;
+            }
+
+            var recognised = ExtractRecognisedText(message);
+            if (string.IsNullOrWhiteSpace(recognised))
+            {
+                return;
+            }
+
+            recognised = recognised.Trim();
+            if (logDebugMessages)
+            {
+                Debug.Log($"[RobotVoice] Recognised: {recognised}");
+            }
+
+            if (IsOnCooldown())
+            {
+                if (logDebugMessages)
+                {
+                    Debug.Log("[RobotVoice] Ignoring speech because of cooldown");
+                }
+                return;
+            }
+
+            var processed = ApplyWakeWord(recognised);
+            if (processed == null)
+            {
+                return;
+            }
+
+            if (IsExitIntent(processed))
+            {
+                PublishExit(recognised);
+                return;
+            }
+
+            if (TryExtractGameName(processed, out var gameName))
+            {
+                PublishLaunch(gameName, recognised);
+            }
+            else if (!requireLaunchKeyword && !string.IsNullOrWhiteSpace(processed))
+            {
+                PublishLaunch(runtimeConfig.ResolveGameName(processed), recognised);
+            }
+        }
+
+        private bool IsOnCooldown()
+        {
+            return Time.realtimeSinceStartup - lastIntentTime < Mathf.Max(0.1f, intentCooldownSeconds);
+        }
+
+        private string ApplyWakeWord(string recognised)
+        {
+            var configuredWakeWord = runtimeConfig.WakeWord?.Trim();
+            if (string.IsNullOrEmpty(configuredWakeWord))
+            {
+                return recognised;
+            }
+
+            if (recognised.StartsWith(configuredWakeWord, StringComparison.OrdinalIgnoreCase))
+            {
+                return recognised.Substring(configuredWakeWord.Length).TrimStart();
+            }
+
+            if (requireWakeWord)
+            {
+                if (logDebugMessages)
+                {
+                    Debug.Log($"[RobotVoice] Wake word '{configuredWakeWord}' missing in '{recognised}'");
+                }
+                return null;
+            }
+
+            return recognised;
+        }
+
+        private bool IsExitIntent(string recognised)
+        {
+            var keywords = runtimeConfig.ExitKeywords;
+            if (keywords == null)
+            {
+                return false;
+            }
+
+            foreach (var keyword in keywords)
+            {
+                if (string.IsNullOrWhiteSpace(keyword))
+                {
+                    continue;
+                }
+
+                if (recognised.IndexOf(keyword.Trim(), StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool TryExtractGameName(string recognised, out string gameName)
+        {
+            gameName = string.Empty;
+            var keywords = runtimeConfig.LaunchKeywords;
+            if (keywords != null)
+            {
+                foreach (var keyword in keywords)
+                {
+                    if (string.IsNullOrWhiteSpace(keyword))
+                    {
+                        continue;
+                    }
+
+                    var index = recognised.IndexOf(keyword.Trim(), StringComparison.OrdinalIgnoreCase);
+                    if (index >= 0)
+                    {
+                        var candidate = recognised.Substring(index + keyword.Length).Trim();
+                        if (!string.IsNullOrWhiteSpace(candidate))
+                        {
+                            gameName = runtimeConfig.ResolveGameName(candidate);
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void PublishLaunch(string gameName, string rawText)
+        {
+            if (string.IsNullOrWhiteSpace(gameName))
+            {
+                if (logDebugMessages)
+                {
+                    Debug.Log("[RobotVoice] Launch intent ignored because the game name is empty");
+                }
+                return;
+            }
+
+            lastIntentTime = Time.realtimeSinceStartup;
+            _ = publisher.PublishLaunchIntentAsync(gameName, rawText);
+        }
+
+        private void PublishExit(string rawText)
+        {
+            lastIntentTime = Time.realtimeSinceStartup;
+            _ = publisher.PublishExitIntentAsync(rawText);
+        }
+
+        private static string ExtractRecognisedText(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = message.Trim();
+            if (!trimmed.StartsWith("{"))
+            {
+                return trimmed;
+            }
+
+            var key = "\"text\"";
+            var keyIndex = trimmed.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+            if (keyIndex < 0)
+            {
+                return trimmed;
+            }
+
+            var colonIndex = trimmed.IndexOf(':', keyIndex + key.Length);
+            if (colonIndex < 0)
+            {
+                return trimmed;
+            }
+
+            var index = colonIndex + 1;
+            while (index < trimmed.Length && char.IsWhiteSpace(trimmed[index]))
+            {
+                index++;
+            }
+
+            if (index >= trimmed.Length || trimmed[index] != '\"')
+            {
+                return trimmed;
+            }
+
+            index++;
+            var sb = new StringBuilder();
+            while (index < trimmed.Length)
+            {
+                var ch = trimmed[index++];
+                if (ch == '\\')
+                {
+                    if (index >= trimmed.Length)
+                    {
+                        break;
+                    }
+
+                    var escape = trimmed[index++];
+                    switch (escape)
+                    {
+                        case '"':
+                            sb.Append('"');
+                            break;
+                        case '\\':
+                            sb.Append('\\');
+                            break;
+                        case '/':
+                            sb.Append('/');
+                            break;
+                        case 'b':
+                            sb.Append('\b');
+                            break;
+                        case 'f':
+                            sb.Append('\f');
+                            break;
+                        case 'n':
+                            sb.Append('\n');
+                            break;
+                        case 'r':
+                            sb.Append('\r');
+                            break;
+                        case 't':
+                            sb.Append('\t');
+                            break;
+                        case 'u':
+                            if (index + 4 <= trimmed.Length)
+                            {
+                                var hex = trimmed.Substring(index, 4);
+                                if (ushort.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var code))
+                                {
+                                    sb.Append(char.ConvertFromUtf32(code));
+                                }
+                                index += 4;
+                            }
+                            break;
+                        default:
+                            sb.Append(escape);
+                            break;
+                    }
+                }
+                else if (ch == '"')
+                {
+                    break;
+                }
+                else
+                {
+                    sb.Append(ch);
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/releases/current/voice/unity_vosk_launcher/VoiceIntentConfig.cs
+++ b/releases/current/voice/unity_vosk_launcher/VoiceIntentConfig.cs
@@ -1,0 +1,120 @@
+using System;
+using UnityEngine;
+
+namespace RobotVoice
+{
+    [Serializable]
+    public class SynonymOverride
+    {
+        public string Spoken;
+        public string GameName;
+
+        public string NormalizeGameName()
+        {
+            return string.IsNullOrWhiteSpace(GameName) ? string.Empty : GameName.Trim();
+        }
+
+        public string NormalizeSpoken()
+        {
+            return string.IsNullOrWhiteSpace(Spoken) ? string.Empty : Spoken.Trim();
+        }
+    }
+
+    [Serializable]
+    public class VoiceIntentConfig
+    {
+        public string WakeWord = string.Empty;
+        public string[] LaunchKeywords = Array.Empty<string>();
+        public string[] ExitKeywords = Array.Empty<string>();
+        public SynonymOverride[] SynonymOverrides = Array.Empty<SynonymOverride>();
+
+        public static VoiceIntentConfig LoadFromJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new VoiceIntentConfig();
+            }
+
+            try
+            {
+                var config = JsonUtility.FromJson<VoiceIntentConfig>(json);
+                return config ?? new VoiceIntentConfig();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[RobotVoice] Failed to parse VoiceIntentConfig JSON: {ex.Message}");
+                return new VoiceIntentConfig();
+            }
+        }
+
+        public string ResolveGameName(string candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = candidate.Trim();
+            if (SynonymOverrides == null || SynonymOverrides.Length == 0)
+            {
+                return trimmed;
+            }
+
+            foreach (var synonym in SynonymOverrides)
+            {
+                if (synonym == null)
+                {
+                    continue;
+                }
+
+                var spoken = synonym.NormalizeSpoken();
+                if (string.IsNullOrEmpty(spoken))
+                {
+                    continue;
+                }
+
+                if (string.Equals(spoken, trimmed, StringComparison.OrdinalIgnoreCase))
+                {
+                    var mapped = synonym.NormalizeGameName();
+                    return string.IsNullOrEmpty(mapped) ? trimmed : mapped;
+                }
+            }
+
+            return trimmed;
+        }
+
+        public bool MatchesExitKeyword(string text)
+        {
+            return ContainsKeyword(ExitKeywords, text);
+        }
+
+        public bool ContainsLaunchKeyword(string text)
+        {
+            return ContainsKeyword(LaunchKeywords, text);
+        }
+
+        private static bool ContainsKeyword(string[] list, string text)
+        {
+            if (list == null || list.Length == 0 || string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            var normalised = text.Trim();
+            foreach (var keyword in list)
+            {
+                if (string.IsNullOrWhiteSpace(keyword))
+                {
+                    continue;
+                }
+
+                if (normalised.IndexOf(keyword.Trim(), StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/releases/current/voice/unity_vosk_launcher/voice_intents.example.json
+++ b/releases/current/voice/unity_vosk_launcher/voice_intents.example.json
@@ -1,0 +1,10 @@
+{
+  "WakeWord": "嘿机器人",
+  "LaunchKeywords": ["打开", "启动", "open", "play"],
+  "ExitKeywords": ["退出", "回到大厅", "quit", "back to lobby"],
+  "SynonymOverrides": [
+    { "Spoken": "Sample Notepad", "GameName": "记事本" },
+    { "Spoken": "记事本", "GameName": "记事本" },
+    { "Spoken": "notebook", "GameName": "记事本" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Unity-side MQTT publisher and speech intent parser scripts for Unity_Vosk
- document setup workflow and provide sample intent configuration for speech-driven game launch

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a273dfb083319be3172a6d8637c2